### PR TITLE
Removed date from pages and made separate post template for blog posts

### DIFF
--- a/templates/post.hbt
+++ b/templates/post.hbt
@@ -3,7 +3,7 @@
 <div class="container">
 <article>
   <h1>{{title}}</h1>
-
+  <p class="date">{{prettifyDate date}}</p>
   {{{contents}}}
 </article>
 </div>


### PR DESCRIPTION
Hey, split your templates up so there's a page and post template, so you don't have the date on every entity
